### PR TITLE
Refactor caches

### DIFF
--- a/checkpy/caches.py
+++ b/checkpy/caches.py
@@ -2,28 +2,13 @@ import sys
 
 _caches = []
 
-class _Cache(object):
-	def __init__(self):
-		self._cache = {}
+
+class _Cache(dict):
+	"""A dict() subclass that appends a self-reference to _caches"""
+	def __init__(self, *args, **kwargs):
+		super(_Cache, self).__init__(*args, **kwargs)
 		_caches.append(self)
 
-	def __setitem__(self, key, value):
-		self._cache[key] = value
-
-	def __getitem__(self, key):
-		return self._cache.get(key, None)
-
-	def __contains__(self, key):
-		return key in self._cache
-
-	def delete(self, key):
-		if key not in self._cache:
-			return False
-		del self._cache[key]
-		return True
-
-	def clear(self):
-		self._cache.clear()
 
 """
 cache decorator
@@ -48,7 +33,7 @@ def cache(*keys):
 
 			if key not in localCache:
 				localCache[key] = func(*args, **kwargs)
-				
+
 			return localCache[key]
 		return cachedFuncWrapper
 	return cacheWrapper


### PR DESCRIPTION
This doesn't fix a real bug, but I ran into this when I encountered a syntax error in a test. Instead of the test throwing an exception, I got a `TypeError` (which turned out to be from the `checkpy.caches.cache` memoization decorator). Subsequently while trying to debug in `ipython`, the function signatures where hidden by the decorator. So it was hard to find out which function was throwing the exception.

This PR solves both issues. Fixes #8.

Changes:
- Make sure cache keys are hashable by using `str()`
- Use `functools.wraps` to expose wrapped function `__doc__`, `__name__` etc.
- `_Cache` as minimal subclass of `dict` 

I feel this code needs to explain why `sys.argv` needs to be a key. From the code I cannot understand, why sys.argv could have a side effect on a cached function, and both the issue (#7) and commit (a54408460c60a2773c9436194233af6932106a84) are very non-descript.