### PR TITLE
capture stderr as well as stdout

### DIFF
--- a/checkpy/entities/function.py
+++ b/checkpy/entities/function.py
@@ -56,17 +56,20 @@ class Function(object):
 		returns a _StreamListener on said stream
 		"""
 		outStreamListener = _StreamListener(_outStream)
-		old = sys.stdout
+		old_stdout = sys.stdout
+		old_stderr = sys.stdout
 
 		outStreamListener.start()
 		sys.stdout = outStreamListener.stream
+		sys.stderr = sys.stdout
 
 		try:
 			yield outStreamListener
 		except:
 			raise
 		finally:
-			sys.stdout = old
+			sys.stdout = old_stdout
+			sys.stderr = old_stderr
 			outStreamListener.stop()
 
 class _Stream(io.StringIO):

--- a/checkpy/entities/function.py
+++ b/checkpy/entities/function.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import contextlib
 import inspect
@@ -17,7 +18,7 @@ class Function(object):
 		try:
 			with self._captureStdout() as listener:
 				outcome = self._function(*args, **kwargs)
-				self._printOutput = ""#listener.content
+				self._printOutput = listener.content
 				return outcome
 		except Exception as e:
 			sys.stdout = old
@@ -57,19 +58,19 @@ class Function(object):
 		"""
 		outStreamListener = _StreamListener(_outStream)
 		old_stdout = sys.stdout
-		old_stderr = sys.stdout
-
-		outStreamListener.start()
-		sys.stdout = outStreamListener.stream
-		sys.stderr = sys.stdout
+		old_stderr = sys.stderr
 
 		try:
+			outStreamListener.start()
+			sys.stdout = outStreamListener.stream
+			sys.stderr = open(os.devnull)
 			yield outStreamListener
 		except:
 			raise
 		finally:
-			sys.stdout = old_stdout
+			sys.stderr.close()
 			sys.stderr = old_stderr
+			sys.stdout = old_stdout
 			outStreamListener.stop()
 
 class _Stream(io.StringIO):

--- a/checkpy/lib/basic.py
+++ b/checkpy/lib/basic.py
@@ -1,5 +1,6 @@
 import sys
 import re
+import os
 try:
 	# Python 2
 	import StringIO
@@ -250,16 +251,15 @@ def captureStdout(stdout=None):
 
 	if stdout is None:
 		stdout = StringIO.StringIO()
-		stderr = stdout
-
-	sys.stdout = stdout
-	sys.stderr = stdout
 
 	try:
+		sys.stdout = stdout
+		sys.stderr = open(os.devnull)
 		yield stdout
 	except:
 		raise
 	finally:
+		sys.stderr.close()
 		sys.stdout = old_stdout
 		sys.stderr = old_stderr
 

--- a/checkpy/lib/basic.py
+++ b/checkpy/lib/basic.py
@@ -245,16 +245,23 @@ def removeComments(source):
 
 @contextlib.contextmanager
 def captureStdout(stdout=None):
-	old = sys.stdout
+	old_stdout = sys.stdout
+	old_stderr = sys.stderr
+
 	if stdout is None:
 		stdout = StringIO.StringIO()
+		stderr = stdout
+
 	sys.stdout = stdout
+	sys.stderr = stdout
+
 	try:
 		yield stdout
 	except:
 		raise
 	finally:
-		sys.stdout = old
+		sys.stdout = old_stdout
+		sys.stderr = old_stderr
 
 @contextlib.contextmanager
 def captureStdin(stdin=None):


### PR DESCRIPTION
Two questions:

- Would it be OK to capture stderr by default? This is mainly to suppress unneeded output during testing.
- I'm not sure why there's 2 capture functions and what they're for.