### PR TITLE
report wrong no of function arguments without crashing

### DIFF
--- a/checkpy/entities/function.py
+++ b/checkpy/entities/function.py
@@ -27,7 +27,7 @@ class Function(object):
 			if isinstance(e,TypeError):
 				no_arguments = re.search(r"takes (\d+) positional arguments but (\d+) were given", e.__str__())
 				if no_arguments:
-					raise exception.SourceException(exception = None, message = f"your function should take {no_arguments.group(1)} arguments but does not")
+					raise exception.SourceException(exception = None, message = f"the function should take {no_arguments.group(1)} arguments but does not")
 			sys.stdout = old
 			argumentNames = self.arguments
 			nArgs = len(args) + len(kwargs)

--- a/checkpy/entities/function.py
+++ b/checkpy/entities/function.py
@@ -1,8 +1,11 @@
 import os
 import sys
+import re
+
 import contextlib
 import inspect
 import checkpy.entities.exception as exception
+
 if sys.version_info >= (3,0):
 	import io
 else:
@@ -21,6 +24,10 @@ class Function(object):
 				self._printOutput = listener.content
 				return outcome
 		except Exception as e:
+			if isinstance(e,TypeError):
+				no_arguments = re.search(r"takes (\d+) positional arguments but (\d+) were given", e.__str__())
+				if no_arguments:
+					raise exception.SourceException(exception = None, message = f"your function should take {no_arguments.group(1)} arguments but does not")
 			sys.stdout = old
 			argumentNames = self.arguments
 			nArgs = len(args) + len(kwargs)


### PR DESCRIPTION
Calling a function in a test with too many arguments would crash the crash reporting.
This introduces a special cased error with a direct and clear description of the problem.